### PR TITLE
Removed the stuff at the bottom of the doctors index

### DIFF
--- a/app/views/users/doctors.html.erb
+++ b/app/views/users/doctors.html.erb
@@ -38,21 +38,3 @@
     </div>
   </div>
 </div>
-
-
-  <div class="row justify-content-center">
-    <div class="col-sm-8">
-      <div id="doctors">
-        <% @doctors.each do |doctor| %>
-          <h4><%= doctor.prefix %> <%= doctor.first_name %> <%= doctor.last_name %></h4>
-          <p><%= doctor.specialty %></p>
-          <p><%= doctor.country %></p>
-          <p><%= doctor.language %></p>
-          <p><%= doctor.diplomas %></p>
-          <p><%= doctor.status %></p>
-          <%= link_to "open profile", doctor_path(doctor) %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
Removed:  

<div class="row justify-content-center">
    <div class="col-sm-8">
      <div id="doctors">
        <% @doctors.each do |doctor| %>
          <h4><%= doctor.prefix %> <%= doctor.first_name %> <%= doctor.last_name %></h4>
          <p><%= doctor.specialty %></p>
          <p><%= doctor.country %></p>
          <p><%= doctor.language %></p>
          <p><%= doctor.diplomas %></p>
          <p><%= doctor.status %></p>
          <%= link_to "open profile", doctor_path(doctor) %>
        <% end %>
      </div>
    </div>
  </div>
</div>